### PR TITLE
feat: add headless mode config

### DIFF
--- a/robotnik_gazebo_ignition/README.md
+++ b/robotnik_gazebo_ignition/README.md
@@ -12,6 +12,8 @@ ros2 launch robotnik_gazebo_ignition spawn_world.launch.py world:=empty
 
 Available worlds are located in the `worlds` folder of this package. You can replace `empty` with the name of any other world file (without the `.world` extension) to launch a different world.
 
+Also, you can enable or disable the Gazebo GUI by setting the `gui:=true` or `gui:=false` parameter. By default, the GUI is enabled.
+
 ## Spawn Robot
 
 Use the launch file to insert a robot into the Gazebo (Ignition) world.

--- a/robotnik_gazebo_ignition/launch/spawn_world.launch.py
+++ b/robotnik_gazebo_ignition/launch/spawn_world.launch.py
@@ -25,10 +25,11 @@
 import os
 from launch import LaunchDescription
 from launch.actions import GroupAction, IncludeLaunchDescription
-from launch.substitutions import LaunchConfiguration, Command, FindExecutable
-from launch_ros.actions import Node, PushRosNamespace
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
-from launch_ros.descriptions import ParameterValue
+from launch.conditions import IfCondition
+from launch.substitutions import PythonExpression
 from robotnik_common.launch import ExtendedArgument, AddArgumentParser
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 
@@ -52,6 +53,13 @@ def generate_launch_description():
         name='world_path',
         description='world path in gazebo classic',
         default_value=[FindPackageShare('robotnik_gazebo_ignition'), '/worlds/', world, '.world'], # type: ignore
+    )
+    add_to_launcher.add_arg(arg)
+
+    arg = ExtendedArgument(
+        name='gui',
+        description='Set to true to enable gazebo gui, headless mode (default: true)',
+        default_value='true',
     )
     add_to_launcher.add_arg(arg)
 
@@ -96,6 +104,8 @@ def generate_launch_description():
                     ],
                     'on_exit_shutdown':'true'
                 }.items(),
+                # gui is in (true, 1, yes, on) (case insensitive)
+                condition = IfCondition(PythonExpression(["'", params['gui'], "'.strip().lower() in ('true','1','yes','on')"])),
             ),
             Node(
                 package="ros_gz_bridge",


### PR DESCRIPTION
This pull request adds support for enabling or disabling the Gazebo GUI in the `spawn_world.launch.py` launch file, making it easier to run simulations in either GUI or headless mode. It introduces a new `gui` launch argument, updates the documentation, and uses conditional logic to launch the GUI based on user input.

**Launch configuration improvements:**

* Added a new `gui` argument to `spawn_world.launch.py` to allow users to enable or disable the Gazebo GUI, with the default set to enabled.
* Updated the launch logic to conditionally start the Gazebo GUI based on the value of the `gui` argument, supporting various truthy values (e.g., "true", "1", "yes", "on").

**Documentation updates:**

* Updated `robotnik_gazebo_ignition/README.md` to document the new `gui` parameter and its usage.

**Code cleanup:**

* Removed unused imports and cleaned up import statements in `spawn_world.launch.py`.