### PR TITLE
fix: restore automatic frame selection

### DIFF
--- a/robotnik_gazebo_ignition/README.md
+++ b/robotnik_gazebo_ignition/README.md
@@ -117,7 +117,7 @@ ros2 launch robotnik_gazebo_ignition spawn_robot.launch.py robot_id:=<unique_nam
 | Name | Required | Purpose | Example |
 |---|---|---|---|
 | `robot_id` | no | Instance name for the spawned robot | `robot_a` |
-| `robot` | yes | Robot **type** to spawn, see `supported_robots` | `rbwatcher` |
+| `robot` | no | Robot **type** to spawn, see `supported_robots`, default is `rbwatcher` | `rbwatcher` |
 | `robot_model` | no | Specific **model** within the type, see `supported_robots` | `rbwatcher` |
 | `x` `y` `z` | no | Spawn position in meters | `0.0 0.0 0.0` |
 | `run_rviz` | no | Launch RViz2 with a predefined configuration | `true` or `false` |

--- a/robotnik_gazebo_ignition/README.md
+++ b/robotnik_gazebo_ignition/README.md
@@ -121,6 +121,7 @@ ros2 launch robotnik_gazebo_ignition spawn_robot.launch.py robot_id:=<unique_nam
 | `robot_model` | no | Specific **model** within the type, see `supported_robots` | `rbwatcher` |
 | `x` `y` `z` | no | Spawn position in meters | `0.0 0.0 0.0` |
 | `run_rviz` | no | Launch RViz2 with a predefined configuration | `true` or `false` |
+| `rviz_config` | no | Full path to a custom RViz2 configuration file (overrides default config and fixed frame must be set in config) | `/path/to/custom_config.rviz` |
 
 #### Supported Robots
 

--- a/robotnik_gazebo_ignition/launch/spawn_robot.launch.py
+++ b/robotnik_gazebo_ignition/launch/spawn_robot.launch.py
@@ -265,12 +265,33 @@ def launch_setup(context, params):
         output='screen',
     ))
 
+    # Check if rviz config path is modified, if not use default fixed frame
+    rviz_config_default = str(
+        Path(
+            FindPackageShare('robotnik_gazebo_ignition').perform(context)
+        )
+        / 'config'
+        / 'rviz_config.rviz'
+    )
+    use_fixed_frame = False
+    # Determine if fixed frame should be used
+    if isinstance(params['rviz_config'], LaunchConfiguration):
+        rviz_config_value = params['rviz_config'].perform(context)
+        use_fixed_frame = (rviz_config_value == "")
+    else:
+        use_fixed_frame = (params['rviz_config'] == "")
+
+    if use_fixed_frame:
+        params['rviz_config'] = rviz_config_default
+
     # RViz
     ret.append(Node(
         package="rviz2",
         executable="rviz2",
         namespace=params['robot_id'],
         arguments=[
+            # Fixed frame
+            ['-f ', params['robot_id'], '_odom'] if use_fixed_frame else [],
             # Config file
             '-d', [params['rviz_config']],
             # Window name
@@ -293,7 +314,7 @@ def generate_launch_description():
         ("z", "Initial Z Coordinate", "0.0", "Z"),
         ("has_arm", "Enable Arm Controller", "False", "HAS_ARM"),
         ("run_rviz", "Run RViz", "True", "RUN_RVIZ"),
-        ("rviz_config", "RViz configuration file", [FindPackageShare('robotnik_gazebo_ignition'), '/config/rviz_config.rviz'], "CONFIG_RVIZ"),
+        ("rviz_config", "RViz configuration file", "", "CONFIG_RVIZ"),
         ("use_sim_time", "Use simulation time", "True", "USE_SIM_TIME"),
 
     ]

--- a/robotnik_gazebo_ignition/launch/spawn_robot.launch.py
+++ b/robotnik_gazebo_ignition/launch/spawn_robot.launch.py
@@ -291,7 +291,7 @@ def launch_setup(context, params):
         namespace=params['robot_id'],
         arguments=[
             # Fixed frame
-            ['-f ', params['robot_id'], '_odom'] if use_fixed_frame else [],
+            ['-f', params['robot_id'], '_odom'] if use_fixed_frame else [],
             # Config file
             '-d', [params['rviz_config']],
             # Window name

--- a/robotnik_gazebo_ignition/launch/spawn_robot.launch.py
+++ b/robotnik_gazebo_ignition/launch/spawn_robot.launch.py
@@ -306,7 +306,7 @@ def launch_setup(context, params):
 def generate_launch_description():
     raw_args = [
         ("robot_id", "Unique Robot Identifier", "robot", "ROBOT_ID"),
-        ("robot", "Robot Model Name", "", "ROBOT"),
+        ("robot", "Robot Model Name", "rbwatcher", "ROBOT"),
         ("robot_model", "Robot Variant or Type", LaunchConfiguration('robot'), "ROBOT_MODEL"),
         ("robot_xacro", "Path to Robot Xacro File", [FindPackageShare('robotnik_description'), '/robots/', LaunchConfiguration('robot'), '/', LaunchConfiguration('robot_model'), '.urdf.xacro'], "ROBOT_XACRO"),
         ("x", "Initial X Coordinate", "0.0", "X"),


### PR DESCRIPTION
This pull request adds support for specifying a custom RViz2 configuration file when launching a robot in the `robotnik_gazebo_ignition` package. It also improves handling of the fixed frame in RViz2 to ensure proper visualization when a custom config is not provided.

**RViz2 configuration improvements:**

* Added a new `rviz_config` launch parameter, allowing users to specify the full path to a custom RViz2 configuration file. This is documented in the `README.md`.
* Updated the launch logic in `spawn_robot.launch.py` to check if a custom RViz2 config is provided. If not, it defaults to the package's standard config and sets the fixed frame to `<robot_id>_odom` for correct visualization.
* Changed the default value for the `rviz_config` launch argument from the package default to an empty string, so users must explicitly provide a custom config if desired.