### PR TITLE
fix: link for gazebo simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Simulation-based environments and launch assets for Robotnik platforms on ROS 2.
 
 | Simulator | Package | Instructions |
 |-----------|---------|--------------|
-| <a href="robotnik_gazebo/README.md"><img src="docs/assets/img/gazebo-logo.png" alt="Gazebo Logo" height=50></a> | `robotnik_gazebo_ignition` | [README](robotnik_gazebo_ignition/README.md) |
+| <a href="robotnik_gazebo_ignition/README.md"><img src="docs/assets/img/gazebo-logo.png" alt="Gazebo Logo" height=50></a> | `robotnik_gazebo_ignition` | [README](robotnik_gazebo_ignition/README.md) |
 
 ## Related projects
 


### PR DESCRIPTION
This pull request updates a link in the `README.md` file to ensure it correctly points to the `robotnik_gazebo_ignition` package documentation. This change improves the accuracy and usability of the documentation.

- Documentation fix:
  * Updated the link for the Gazebo simulator in the table to reference `robotnik_gazebo_ignition/README.md` instead of `robotnik_gazebo/README.md`.