### PR TITLE
fix: resolve robot vs. robot_model arguments in complete_bringup.laun…

### DIFF
--- a/common/robotnik_simulation_bringup/launch/bringup_complete.launch.py
+++ b/common/robotnik_simulation_bringup/launch/bringup_complete.launch.py
@@ -41,9 +41,14 @@ def generate_launch_description():
             description="Name for launch and config resources"
         ),
         DeclareLaunchArgument(
-            "robot_model",
+            "robot",
             default_value="rbsummit",
             description="Set robot model"
+        ),
+        DeclareLaunchArgument(
+            "robot_model",
+            default_value="rbsummit",
+            description="Set robot subvariant model"
         ),
         DeclareLaunchArgument(
             "use_gui",
@@ -71,6 +76,7 @@ def generate_launch_description():
     ]
 
     robot_id = LaunchConfiguration("robot_id")
+    robot = LaunchConfiguration("robot")
     robot_model = LaunchConfiguration("robot_model")
     use_gui = LaunchConfiguration("use_gui")
     low_performance_simulation = LaunchConfiguration("low_performance_simulation")
@@ -98,7 +104,8 @@ def generate_launch_description():
         ),
         launch_arguments={
             'robot_id': robot_id,
-            'robot': robot_model,
+            'robot': robot,
+            'robot_model': robot_model,
             'low_performance_simulation': low_performance_simulation,
             'run_rviz': 'false'
         }.items()


### PR DESCRIPTION
This PR resolves an issue in `bringup_complete.launch.py` where the `robot` and `robot_model` launch arguments were conflated. It separates the top-level robot definition from its subvariant model, allowing for more accurate configuration and spawning.

### Type of Change

[x] Bug fix (non-breaking change which fixes an issue)

[ ] New feature (non-breaking change which adds functionality)

[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

[ ] Documentation Update

### Changes Made
* Added `robot` Launch Argument: Introduced a dedicated `robot` argument (default: `rbsummit`) to specify the base robot type.
* Updated `robot_model` Purpose: Redefined the existing `robot_model` argument to explicitly handle the robot's subvariant model (e.g., rbvogui_plus, rbkairos_plus, etc.), defaulting to `rbsummit`.
* Corrected Context Passing: Updated the launch_arguments passed to `bringup_base.launch.py` to properly propagate both the `robot` and `robot_model` arguments independently, fixing the previous behavior where robot was incorrectly assigned the value of `robot_model` to `robot` arg.

### Motivation and Context
Previously, `bringup_complete.launch.py` only accepted a `robot_model` argument and erroneously passed it as the `robot` argument to downstream launch files. This prevented users from properly specifying both the base robot and its specific subvariant (model) simultaneously. The problem was critically when user wanted to work with VOGUI+ or RBKAIROS+ robots. By explicitly decoupling these arguments, we prevent configuration conflicts and ensure proper model URDF loading and simulation bringup for robots with multiple subvariants.

### How Has This Been Tested?
* Verified that `bringup_complete.launch.py` successfully accepts both robot and robot_model arguments.
* Confirmed that downstream launch files correctly receive both parameters without conflation.