### PR TITLE
Fix version of repos for jazzy devel

### DIFF
--- a/dependencies/repos/common.repo.yml
+++ b/dependencies/repos/common.repo.yml
@@ -25,30 +25,34 @@
 # EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ---
 repositories:
-  src/robotnik_simulation:
+
+  # Robotnik repositories
+  src/robotnik/robotnik_simulation:
     type: git
     url: https://github.com/RobotnikAutomation/robotnik_simulation.git
     version: jazzy-devel
-  src/robotnik_description:
+  src/robotnik/robotnik_description:
     type: git
     url: https://github.com/RobotnikAutomation/robotnik_description.git
     version: jazzy-devel
-  src/robotnik_sensors:
+  src/robotnik/robotnik_sensors:
     type: git
     url: https://github.com/RobotnikAutomation/robotnik_sensors.git
     version: jazzy-devel
-  src/robotnik_common:
+  src/robotnik/robotnik_common:
     type: git
     url: https://github.com/RobotnikAutomation/robotnik_common.git
     version: jazzy-devel
-  src/robotnik_interfaces:
+  src/robotnik/robotnik_interfaces:
     type: git
     url: https://github.com/RobotnikAutomation/robotnik_interfaces.git
     version: jazzy-devel
-  src/robotnik_moveit_configs:
+  src/robotnik/robotnik_moveit_configs:
     type: git
     url: https://github.com/RobotnikAutomation/robotnik_moveit_configs.git
     version: jazzy-devel
+
+  # Third-party repositories
   src/ros-control/gz_ros2_control:
     type: git
     url: https://github.com/ros-controls/gz_ros2_control.git

--- a/robotnik_simulation.jazzy.repos
+++ b/robotnik_simulation.jazzy.repos
@@ -21,19 +21,19 @@ repositories:
   robotnik/robotnik_common:
     type: git
     url: https://github.com/RobotnikAutomation/robotnik_common.git
-    version: 1.2.0
+    version: jazzy-devel
   robotnik/robotnik_description:
     type: git
     url: https://github.com/RobotnikAutomation/robotnik_description.git
-    version: 2.2.0
+    version: jazzy-devel
   robotnik/robotnik_interfaces:
     type: git
     url: https://github.com/RobotnikAutomation/robotnik_interfaces.git
-    version: 1.1.0
+    version: jazzy-devel
   robotnik/robotnik_sensors:
     type: git
     url: https://github.com/RobotnikAutomation/robotnik_sensors.git
-    version: 2.2.0
+    version: jazzy-devel
   robotnik/robotnik_simulation:
     type: git
     url: https://github.com/RobotnikAutomation/robotnik_simulation.git


### PR DESCRIPTION
## 📝 Descripción
Este PR soluciona un problema de sincronización en la importación de repositorios (`vcs import`). 
Actualmente, el `README` apunta al archivo `robotnik_simulation.jazzy.repos` para descargar las dependencias. Sin embargo, las versiones correctas solo se habían actualizado en `dependencies/repos/common.repos`, dejando el archivo principal desactualizado y provocando que se importaran versiones incorrectas.

En este PR he igualado las versiones de `robotnik_simulation.jazzy.repos` para que todo vuelva a funcionar correctamente.

## 🛠️ Cambios realizados
* Actualización de la rama jazzy-devel en `robotnik_simulation.jazzy.repos` para que coincidan con las requeridas para Jazzy.

## ⚠️ Notas adicionales y propuesta de mejora (Refactor)
Al investigar este bug, he notado un problema en la estructura de nuestros archivos `.repos` que creo que deberíamos debatir para un futuro PR:

1. **Duplicidad redundante:** Actualmente tenemos un `dependencies/repos/common.repos` y un `robotnik_simulation.[distro].repos` separados. Al tener una rama dedicada para cada distribución de ROS, cada rama debería tener simplemente su `common.repo.yml` adaptado a su versión (o llamado [distro].repo.yml). Mantener ambos nos obliga a duplicar el trabajo y es la causa raíz del bug que soluciona este PR.
2. **Bug detectado en Humble:** He revisado la rama de `humble` y su `common.repos` está apuntando directamente a las ramas de `jazzy`. Esto va a generar incompatibilidades pronto. Por lo que hay que revisar si los cambios aportados a las ramas de jazzy-devel están importados también a humble y cambiar las vesriones, o si por el contrario hay que portar y actualizar los cambios para la rama de humble. 