### PR TITLE
Fix: remove arm controllers from rb-summit steel parameters

### DIFF
--- a/robotnik_gazebo_ignition/config/profile/rbsummit_steel/rbsummit_steel_ros2_control.yaml
+++ b/robotnik_gazebo_ignition/config/profile/rbsummit_steel/rbsummit_steel_ros2_control.yaml
@@ -103,28 +103,3 @@
               acceleration:
                 min: -10.0
                 max: 10.0
-
-  # HAS ARM
-  joint_trajectory_controller:
-    ros__parameters:
-      publish_rate: 50
-      joints:
-        - $(var frame_prefix)arm_shoulder_pan_joint
-        - $(var frame_prefix)arm_shoulder_lift_joint
-        - $(var frame_prefix)arm_elbow_joint
-        - $(var frame_prefix)arm_wrist_1_joint
-        - $(var frame_prefix)arm_wrist_2_joint
-        - $(var frame_prefix)arm_wrist_3_joint
-
-      command_interfaces:
-        - position
-
-      state_interfaces:
-        - position
-        - velocity
-
-      state_publish_rate: 50.0
-      action_monitor_rate: 20.0
-
-      allow_partial_joints_goal: false
-      open_loop_control: true


### PR DESCRIPTION
## Description
This PR fixes a Gazebo crash (segmentation fault) during the simulation startup of the **rb-summit steel** robot. 

The issue was caused by a mismatch between the controller parameters and the robot's URDF description. The profile configuration for this specific robot still maintained control parameters for an arm, but the actual URDF does not include any arm manipulation segments. As a result, Gazebo threw an error when attempting to assign controllers and trajectories to non-existing joints.

This addresses the same root cause previously fixed in the `manipulation` update.

## Changes
* Removed arm controller configurations and joint assignments from the `rb_summit_steel` specific configuration files `rb_summit_steel_control.yaml`.

## How to test
1. Launch the `rb_summit_steel` simulation in Gazebo.
2. Verify that Gazebo launches successfully without any segmentation faults or missing joint errors in the terminal output.